### PR TITLE
Fix path corruption when shortening very long file paths.

### DIFF
--- a/mtftar.c
+++ b/mtftar.c
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 			/* have TAPE header/characteristics */
 			if (verbose) {
 				str = mtfscan_string(&s, mtfdb_tape_software(&s), '/');
-				fprintf(stderr, "MFT Generator: %s\n", str);
+				fprintf(stderr, "MTF Generator: %s\n", str);
 				free(str);
 
 				str = mtfscan_string(&s, mtfdb_tape_name(&s), '/');

--- a/tarout.c
+++ b/tarout.c
@@ -103,15 +103,13 @@ int tarout_heading(struct tar_stream *t, int type,
 				 * then chomp up to slash
 				 */
 				pfn_len = i;
-				for (i = 0; i - pfn_len > 155;) {
-					for (; i < pfn_len; i++) {
-						if (filename[i] == '/') {
-							pfn_len -= (i+1);
-						}
+				for (i = 0; pfn_len > 155; i++) {
+					if (filename[i] == '/') {
+						pfn_len = lfn - (filename + i + 1);
 					}
 				}
 				if (pfn_len > 0) {
-					pfn = filename+i+1;
+					pfn = filename+i;
 				}
 			} else {
 				pfn = filename;


### PR DESCRIPTION
This PR also inherits bugfixes and OSX compatibility work by sjmurdoch and nledevil, as well as the original mtf project for reference, including the MTF specification.