### PR TITLE
Implement POSIX.1-2001 pax headers for path and size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.o
+mtftar
+md5/md5main
+
+# Eclipse
+.settings
+.cproject
+.project
+
+# KDevelop
+*.kdev4

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 CFLAGS += -Wall -O3 -D_GNU_SOURCE
 
+vpath md5.% md5
+
 #test: mtftar
 #	./mtftar -X "`./mtftar -s1 -L -f READY.bkf`" -p -f READY.bkf d:/inetpub/ | tar tvf -
 
-mtftar: mtftar.o mtfscan.o mtfheader.o mtfstream.o tarout.o util.o
+mtftar: mtftar.o mtfscan.o mtfheader.o mtfstream.o tarout.o util.o md5/md5.o -lm
 mtftar.o: mtftar.c mtf.h tar.h
 mtfstream.o: mtfstream.c mtf.h
 mtfscan.o: mtfscan.c mtf.h
@@ -14,4 +16,6 @@ tarout.o: tarout.c tar.h
 
 util.o: util.c util.h
 
-clean:;rm -f *.o mtftar
+md5/md5.o: md5/md5.c md5/md5.h
+
+clean:;rm -f *.o md5/*.o mtftar

--- a/md5/Makefile
+++ b/md5/Makefile
@@ -1,0 +1,8 @@
+CFLAGS += -Wall -D_GNU_SOURCE -fno-strict-aliasing
+LDFLAGS += -Wall -D_GNU_SOURCE -fno-strict-aliasing
+LDLIBS = -lm
+
+md5main: md5main.c md5.c md5.h
+
+clean:;rm -f *.o md5main
+

--- a/md5/md5.c
+++ b/md5/md5.c
@@ -1,0 +1,381 @@
+/*
+  Copyright (C) 1999, 2000, 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5.c,v 1.6 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.c is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Clarified derivation from RFC 1321; now handles byte order
+	either statically or dynamically; added missing #include <string.h>
+	in library.
+  2002-03-11 lpd Corrected argument list for main(), and added int return
+	type, in test program and T value program.
+  2002-02-21 lpd Added missing #include <stdio.h> in test program.
+  2000-07-03 lpd Patched to eliminate warnings about "constant is
+	unsigned in ANSI C, signed in traditional"; made test program
+	self-checking.
+  1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
+  1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5).
+  1999-05-03 lpd Original version.
+ */
+
+#include "md5.h"
+#include <string.h>
+
+#undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
+#ifdef ARCH_IS_BIG_ENDIAN
+#  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
+#else
+#  define BYTE_ORDER 0
+#endif
+
+#define T_MASK ((md5_word_t)~0)
+#define T1 /* 0xd76aa478 */ (T_MASK ^ 0x28955b87)
+#define T2 /* 0xe8c7b756 */ (T_MASK ^ 0x173848a9)
+#define T3    0x242070db
+#define T4 /* 0xc1bdceee */ (T_MASK ^ 0x3e423111)
+#define T5 /* 0xf57c0faf */ (T_MASK ^ 0x0a83f050)
+#define T6    0x4787c62a
+#define T7 /* 0xa8304613 */ (T_MASK ^ 0x57cfb9ec)
+#define T8 /* 0xfd469501 */ (T_MASK ^ 0x02b96afe)
+#define T9    0x698098d8
+#define T10 /* 0x8b44f7af */ (T_MASK ^ 0x74bb0850)
+#define T11 /* 0xffff5bb1 */ (T_MASK ^ 0x0000a44e)
+#define T12 /* 0x895cd7be */ (T_MASK ^ 0x76a32841)
+#define T13    0x6b901122
+#define T14 /* 0xfd987193 */ (T_MASK ^ 0x02678e6c)
+#define T15 /* 0xa679438e */ (T_MASK ^ 0x5986bc71)
+#define T16    0x49b40821
+#define T17 /* 0xf61e2562 */ (T_MASK ^ 0x09e1da9d)
+#define T18 /* 0xc040b340 */ (T_MASK ^ 0x3fbf4cbf)
+#define T19    0x265e5a51
+#define T20 /* 0xe9b6c7aa */ (T_MASK ^ 0x16493855)
+#define T21 /* 0xd62f105d */ (T_MASK ^ 0x29d0efa2)
+#define T22    0x02441453
+#define T23 /* 0xd8a1e681 */ (T_MASK ^ 0x275e197e)
+#define T24 /* 0xe7d3fbc8 */ (T_MASK ^ 0x182c0437)
+#define T25    0x21e1cde6
+#define T26 /* 0xc33707d6 */ (T_MASK ^ 0x3cc8f829)
+#define T27 /* 0xf4d50d87 */ (T_MASK ^ 0x0b2af278)
+#define T28    0x455a14ed
+#define T29 /* 0xa9e3e905 */ (T_MASK ^ 0x561c16fa)
+#define T30 /* 0xfcefa3f8 */ (T_MASK ^ 0x03105c07)
+#define T31    0x676f02d9
+#define T32 /* 0x8d2a4c8a */ (T_MASK ^ 0x72d5b375)
+#define T33 /* 0xfffa3942 */ (T_MASK ^ 0x0005c6bd)
+#define T34 /* 0x8771f681 */ (T_MASK ^ 0x788e097e)
+#define T35    0x6d9d6122
+#define T36 /* 0xfde5380c */ (T_MASK ^ 0x021ac7f3)
+#define T37 /* 0xa4beea44 */ (T_MASK ^ 0x5b4115bb)
+#define T38    0x4bdecfa9
+#define T39 /* 0xf6bb4b60 */ (T_MASK ^ 0x0944b49f)
+#define T40 /* 0xbebfbc70 */ (T_MASK ^ 0x4140438f)
+#define T41    0x289b7ec6
+#define T42 /* 0xeaa127fa */ (T_MASK ^ 0x155ed805)
+#define T43 /* 0xd4ef3085 */ (T_MASK ^ 0x2b10cf7a)
+#define T44    0x04881d05
+#define T45 /* 0xd9d4d039 */ (T_MASK ^ 0x262b2fc6)
+#define T46 /* 0xe6db99e5 */ (T_MASK ^ 0x1924661a)
+#define T47    0x1fa27cf8
+#define T48 /* 0xc4ac5665 */ (T_MASK ^ 0x3b53a99a)
+#define T49 /* 0xf4292244 */ (T_MASK ^ 0x0bd6ddbb)
+#define T50    0x432aff97
+#define T51 /* 0xab9423a7 */ (T_MASK ^ 0x546bdc58)
+#define T52 /* 0xfc93a039 */ (T_MASK ^ 0x036c5fc6)
+#define T53    0x655b59c3
+#define T54 /* 0x8f0ccc92 */ (T_MASK ^ 0x70f3336d)
+#define T55 /* 0xffeff47d */ (T_MASK ^ 0x00100b82)
+#define T56 /* 0x85845dd1 */ (T_MASK ^ 0x7a7ba22e)
+#define T57    0x6fa87e4f
+#define T58 /* 0xfe2ce6e0 */ (T_MASK ^ 0x01d3191f)
+#define T59 /* 0xa3014314 */ (T_MASK ^ 0x5cfebceb)
+#define T60    0x4e0811a1
+#define T61 /* 0xf7537e82 */ (T_MASK ^ 0x08ac817d)
+#define T62 /* 0xbd3af235 */ (T_MASK ^ 0x42c50dca)
+#define T63    0x2ad7d2bb
+#define T64 /* 0xeb86d391 */ (T_MASK ^ 0x14792c6e)
+
+
+static void
+md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
+{
+    md5_word_t
+	a = pms->abcd[0], b = pms->abcd[1],
+	c = pms->abcd[2], d = pms->abcd[3];
+    md5_word_t t;
+#if BYTE_ORDER > 0
+    /* Define storage only for big-endian CPUs. */
+    md5_word_t X[16];
+#else
+    /* Define storage for little-endian or both types of CPUs. */
+    md5_word_t xbuf[16];
+    const md5_word_t *X;
+#endif
+
+    {
+#if BYTE_ORDER == 0
+	/*
+	 * Determine dynamically whether this is a big-endian or
+	 * little-endian machine, since we can use a more efficient
+	 * algorithm on the latter.
+	 */
+	static const int w = 1;
+
+	if (*((const md5_byte_t *)&w)) /* dynamic little-endian */
+#endif
+#if BYTE_ORDER <= 0		/* little-endian */
+	{
+	    /*
+	     * On little-endian machines, we can process properly aligned
+	     * data without copying it.
+	     */
+	    if (!((data - (const md5_byte_t *)0) & 3)) {
+		/* data are properly aligned */
+		X = (const md5_word_t *)data;
+	    } else {
+		/* not aligned */
+		memcpy(xbuf, data, 64);
+		X = xbuf;
+	    }
+	}
+#endif
+#if BYTE_ORDER == 0
+	else			/* dynamic big-endian */
+#endif
+#if BYTE_ORDER >= 0		/* big-endian */
+	{
+	    /*
+	     * On big-endian machines, we must arrange the bytes in the
+	     * right order.
+	     */
+	    const md5_byte_t *xp = data;
+	    int i;
+
+#  if BYTE_ORDER == 0
+	    X = xbuf;		/* (dynamic only) */
+#  else
+#    define xbuf X		/* (static only) */
+#  endif
+	    for (i = 0; i < 16; ++i, xp += 4)
+		xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
+	}
+#endif
+    }
+
+#define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+
+    /* Round 1. */
+    /* Let [abcd k s i] denote the operation
+       a = b + ((a + F(b,c,d) + X[k] + T[i]) <<< s). */
+#define F(x, y, z) (((x) & (y)) | (~(x) & (z)))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + F(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+    /* Do the following 16 operations. */
+    SET(a, b, c, d,  0,  7,  T1);
+    SET(d, a, b, c,  1, 12,  T2);
+    SET(c, d, a, b,  2, 17,  T3);
+    SET(b, c, d, a,  3, 22,  T4);
+    SET(a, b, c, d,  4,  7,  T5);
+    SET(d, a, b, c,  5, 12,  T6);
+    SET(c, d, a, b,  6, 17,  T7);
+    SET(b, c, d, a,  7, 22,  T8);
+    SET(a, b, c, d,  8,  7,  T9);
+    SET(d, a, b, c,  9, 12, T10);
+    SET(c, d, a, b, 10, 17, T11);
+    SET(b, c, d, a, 11, 22, T12);
+    SET(a, b, c, d, 12,  7, T13);
+    SET(d, a, b, c, 13, 12, T14);
+    SET(c, d, a, b, 14, 17, T15);
+    SET(b, c, d, a, 15, 22, T16);
+#undef SET
+
+     /* Round 2. */
+     /* Let [abcd k s i] denote the operation
+          a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
+#define G(x, y, z) (((x) & (z)) | ((y) & ~(z)))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + G(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+     /* Do the following 16 operations. */
+    SET(a, b, c, d,  1,  5, T17);
+    SET(d, a, b, c,  6,  9, T18);
+    SET(c, d, a, b, 11, 14, T19);
+    SET(b, c, d, a,  0, 20, T20);
+    SET(a, b, c, d,  5,  5, T21);
+    SET(d, a, b, c, 10,  9, T22);
+    SET(c, d, a, b, 15, 14, T23);
+    SET(b, c, d, a,  4, 20, T24);
+    SET(a, b, c, d,  9,  5, T25);
+    SET(d, a, b, c, 14,  9, T26);
+    SET(c, d, a, b,  3, 14, T27);
+    SET(b, c, d, a,  8, 20, T28);
+    SET(a, b, c, d, 13,  5, T29);
+    SET(d, a, b, c,  2,  9, T30);
+    SET(c, d, a, b,  7, 14, T31);
+    SET(b, c, d, a, 12, 20, T32);
+#undef SET
+
+     /* Round 3. */
+     /* Let [abcd k s t] denote the operation
+          a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
+#define H(x, y, z) ((x) ^ (y) ^ (z))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + H(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+     /* Do the following 16 operations. */
+    SET(a, b, c, d,  5,  4, T33);
+    SET(d, a, b, c,  8, 11, T34);
+    SET(c, d, a, b, 11, 16, T35);
+    SET(b, c, d, a, 14, 23, T36);
+    SET(a, b, c, d,  1,  4, T37);
+    SET(d, a, b, c,  4, 11, T38);
+    SET(c, d, a, b,  7, 16, T39);
+    SET(b, c, d, a, 10, 23, T40);
+    SET(a, b, c, d, 13,  4, T41);
+    SET(d, a, b, c,  0, 11, T42);
+    SET(c, d, a, b,  3, 16, T43);
+    SET(b, c, d, a,  6, 23, T44);
+    SET(a, b, c, d,  9,  4, T45);
+    SET(d, a, b, c, 12, 11, T46);
+    SET(c, d, a, b, 15, 16, T47);
+    SET(b, c, d, a,  2, 23, T48);
+#undef SET
+
+     /* Round 4. */
+     /* Let [abcd k s t] denote the operation
+          a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
+#define I(x, y, z) ((y) ^ ((x) | ~(z)))
+#define SET(a, b, c, d, k, s, Ti)\
+  t = a + I(b,c,d) + X[k] + Ti;\
+  a = ROTATE_LEFT(t, s) + b
+     /* Do the following 16 operations. */
+    SET(a, b, c, d,  0,  6, T49);
+    SET(d, a, b, c,  7, 10, T50);
+    SET(c, d, a, b, 14, 15, T51);
+    SET(b, c, d, a,  5, 21, T52);
+    SET(a, b, c, d, 12,  6, T53);
+    SET(d, a, b, c,  3, 10, T54);
+    SET(c, d, a, b, 10, 15, T55);
+    SET(b, c, d, a,  1, 21, T56);
+    SET(a, b, c, d,  8,  6, T57);
+    SET(d, a, b, c, 15, 10, T58);
+    SET(c, d, a, b,  6, 15, T59);
+    SET(b, c, d, a, 13, 21, T60);
+    SET(a, b, c, d,  4,  6, T61);
+    SET(d, a, b, c, 11, 10, T62);
+    SET(c, d, a, b,  2, 15, T63);
+    SET(b, c, d, a,  9, 21, T64);
+#undef SET
+
+     /* Then perform the following additions. (That is increment each
+        of the four registers by the value it had before this block
+        was started.) */
+    pms->abcd[0] += a;
+    pms->abcd[1] += b;
+    pms->abcd[2] += c;
+    pms->abcd[3] += d;
+}
+
+void
+md5_init(md5_state_t *pms)
+{
+    pms->count[0] = pms->count[1] = 0;
+    pms->abcd[0] = 0x67452301;
+    pms->abcd[1] = /*0xefcdab89*/ T_MASK ^ 0x10325476;
+    pms->abcd[2] = /*0x98badcfe*/ T_MASK ^ 0x67452301;
+    pms->abcd[3] = 0x10325476;
+}
+
+void
+md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
+{
+    const md5_byte_t *p = data;
+    int left = nbytes;
+    int offset = (pms->count[0] >> 3) & 63;
+    md5_word_t nbits = (md5_word_t)(nbytes << 3);
+
+    if (nbytes <= 0)
+	return;
+
+    /* Update the message length. */
+    pms->count[1] += nbytes >> 29;
+    pms->count[0] += nbits;
+    if (pms->count[0] < nbits)
+	pms->count[1]++;
+
+    /* Process an initial partial block. */
+    if (offset) {
+	int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
+
+	memcpy(pms->buf + offset, p, copy);
+	if (offset + copy < 64)
+	    return;
+	p += copy;
+	left -= copy;
+	md5_process(pms, pms->buf);
+    }
+
+    /* Process full blocks. */
+    for (; left >= 64; p += 64, left -= 64)
+	md5_process(pms, p);
+
+    /* Process a final partial block. */
+    if (left)
+	memcpy(pms->buf, p, left);
+}
+
+void
+md5_finish(md5_state_t *pms, md5_byte_t digest[16])
+{
+    static const md5_byte_t pad[64] = {
+	0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+    md5_byte_t data[8];
+    int i;
+
+    /* Save the length before padding. */
+    for (i = 0; i < 8; ++i)
+	data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
+    /* Pad to 56 bytes mod 64. */
+    md5_append(pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
+    /* Append the length. */
+    md5_append(pms, data, 8);
+    for (i = 0; i < 16; ++i)
+	digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
+}

--- a/md5/md5.h
+++ b/md5/md5.h
@@ -1,0 +1,91 @@
+/*
+  Copyright (C) 1999, 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5.h,v 1.4 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.h is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Removed support for non-ANSI compilers; removed
+	references to Ghostscript; clarified derivation from RFC 1321;
+	now handles byte order either statically or dynamically.
+  1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
+  1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5);
+	added conditionalization for C++ compilation from Martin
+	Purschke <purschke@bnl.gov>.
+  1999-05-03 lpd Original version.
+ */
+
+#ifndef md5_INCLUDED
+#  define md5_INCLUDED
+
+/*
+ * This package supports both compile-time and run-time determination of CPU
+ * byte order.  If ARCH_IS_BIG_ENDIAN is defined as 0, the code will be
+ * compiled to run only on little-endian CPUs; if ARCH_IS_BIG_ENDIAN is
+ * defined as non-zero, the code will be compiled to run only on big-endian
+ * CPUs; if ARCH_IS_BIG_ENDIAN is not defined, the code will be compiled to
+ * run on either big- or little-endian CPUs, but will run slightly less
+ * efficiently on either one than if ARCH_IS_BIG_ENDIAN is defined.
+ */
+
+typedef unsigned char md5_byte_t; /* 8-bit byte */
+typedef unsigned int md5_word_t; /* 32-bit word */
+
+/* Define the state of the MD5 Algorithm. */
+typedef struct md5_state_s {
+    md5_word_t count[2];	/* message length in bits, lsw first */
+    md5_word_t abcd[4];		/* digest buffer */
+    md5_byte_t buf[64];		/* accumulate block */
+} md5_state_t;
+
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
+/* Initialize the algorithm. */
+void md5_init(md5_state_t *pms);
+
+/* Append a string to the message. */
+void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
+
+/* Finish the message and return the digest. */
+void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
+
+#ifdef __cplusplus
+}  /* end extern "C" */
+#endif
+
+#endif /* md5_INCLUDED */

--- a/md5/md5main.c
+++ b/md5/md5main.c
@@ -1,0 +1,139 @@
+/*
+  Copyright (C) 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5main.c,v 1.1 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.c is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Splits off main program into a separate file, md5main.c.
+ */
+
+#include "md5.h"
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * This file builds an executable that performs various functions related
+ * to the MD5 library.  Typical compilation:
+ *	gcc -o md5main -lm md5main.c md5.c
+ */
+static const char *const usage = "\
+Usage:\n\
+    md5main --test		# run the self-test (A.5 of RFC 1321)\n\
+    md5main --t-values		# print the T values for the library\n\
+    md5main --version		# print the version of the package\n\
+";
+static const char *const version = "2002-04-13";
+
+/* Run the self-test. */
+static int
+do_test(void)
+{
+    static const char *const test[7*2] = {
+	"", "d41d8cd98f00b204e9800998ecf8427e",
+	"a", "0cc175b9c0f1b6a831c399e269772661",
+	"abc", "900150983cd24fb0d6963f7d28e17f72",
+	"message digest", "f96b697d7cb7938d525a2f31aaf161d0",
+	"abcdefghijklmnopqrstuvwxyz", "c3fcd3d76192e4007dfb496cca67e13b",
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+				"d174ab98d277d9f5a5611c2c9f419d9f",
+	"12345678901234567890123456789012345678901234567890123456789012345678901234567890", "57edf4a22be3c955ac49da2e2107b67a"
+    };
+    int i;
+    int status = 0;
+
+    for (i = 0; i < 7*2; i += 2) {
+	md5_state_t state;
+	md5_byte_t digest[16];
+	char hex_output[16*2 + 1];
+	int di;
+
+	md5_init(&state);
+	md5_append(&state, (const md5_byte_t *)test[i], strlen(test[i]));
+	md5_finish(&state, digest);
+	for (di = 0; di < 16; ++di)
+	    sprintf(hex_output + di * 2, "%02x", digest[di]);
+	if (strcmp(hex_output, test[i + 1])) {
+	    printf("MD5 (\"%s\") = ", test[i]);
+	    puts(hex_output);
+	    printf("**** ERROR, should be: %s\n", test[i + 1]);
+	    status = 1;
+	}
+    }
+    if (status == 0)
+	puts("md5 self-test completed successfully.");
+    return status;
+}
+
+/* Print the T values. */
+static int
+do_t_values(void)
+{
+    int i;
+    for (i = 1; i <= 64; ++i) {
+	unsigned long v = (unsigned long)(4294967296.0 * fabs(sin((double)i)));
+
+	/*
+	 * The following nonsense is only to avoid compiler warnings about
+	 * "integer constant is unsigned in ANSI C, signed with -traditional".
+	 */
+	if (v >> 31) {
+	    printf("#define T%d /* 0x%08lx */ (T_MASK ^ 0x%08lx)\n", i,
+		   v, (unsigned long)(unsigned int)(~v));
+	} else {
+	    printf("#define T%d    0x%08lx\n", i, v);
+	}
+    }
+    return 0;
+}
+
+/* Main program */
+int
+main(int argc, char *argv[])
+{
+    if (argc == 2) {
+	if (!strcmp(argv[1], "--test"))
+	    return do_test();
+	if (!strcmp(argv[1], "--t-values"))
+	    return do_t_values();
+	if (!strcmp(argv[1], "--version")) {
+	    puts(version);
+	    return 0;
+	}
+    }
+    puts(usage);
+    return 0;
+}

--- a/mtftar.c
+++ b/mtftar.c
@@ -9,19 +9,43 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <getopt.h>
+
+/*
+ * From this link, SQL Server uses a slightly different MTF spec, for which documentation seems to be unavailable:
+ *
+ * https://social.msdn.microsoft.com/Forums/en-US/f9feea7e-6bc2-4ec0-9193-91575100c816/i-am-looking-an-mtf-microsoft-tape-format-specification-which-is-100b-or-newer-does-anyone
+ * "I need to try and find the actual MTF Specification as I need to find out how to handle some descriptor
+ * blocks and streams that don't exist in the original ( Version 1.00a ) specification.  In my researching
+ * I have stumbled across this issue created on the Microsoft website. In the comments a
+ * Microsoft employee states that SQL Server uses MTF for it's backups. The version of MTF
+ * it uses is 1.02. It is this specification I am trying to find. ( This is the issue I have found :
+ * connect dot microsoft dot com/SQLServer/feedback/details/585729/backup-created-using-tape-format-1-240-on-win2k8-os-can-not-be-restored-on-win2k3-with-the-same-version-of-sql-server-2008r2  )"
+ */
 
 static void usage(int e)
 {
-	fprintf(stderr, "Usage: mtftar [-v] [-p] [-s setno] [patterns...] < backup.btf | tar xvf -\n");
-	fprintf(stderr, "       mtftar [-v] [-p] [-s setno] -f backup.btf [patterns...] | tar xvf -\n");
-	fprintf(stderr, "       mtftar [-v] [-p] [-s setno] -f backup.btf -o output.tar [patterns...]\n");
-	fprintf(stderr, "       mtftar [-v] [-p] [-s setno] -o output.tar [patterns...] < backup.btf\n");
-	fprintf(stderr, "       mtftar -l [-v] [-s setno] < backup.btf\n");
-	fprintf(stderr, "       mtftar -l [-v] [-s setno] -f backup.btf\n");
-	fprintf(stderr, "       mtftar -L [-v] [-s setno] < backup.btf\n");
-	fprintf(stderr, "       mtftar -L [-v] [-s setno] -f backup.btf\n");
+	fprintf(stderr, "Usage: mtftar [options] [patterns...] < backup.bkf | tar xvf -\n");
+	fprintf(stderr, "       mtftar [options] -f backup.bkf [patterns...] | tar xvf -\n");
+	fprintf(stderr, "       mtftar [options] -f backup.bkf -o output.tar [patterns...]\n");
+	fprintf(stderr, "       mtftar [options] -o output.tar [patterns...] < backup.bkf\n");
+	fprintf(stderr, "       mtftar -l [-v] [-s setno] < backup.bkf\n");
+	fprintf(stderr, "       mtftar -l [-v] [-s setno] -f backup.bkf\n");
+	fprintf(stderr, "       mtftar -L [-v] [-s setno] < backup.bkf\n");
+	fprintf(stderr, "       mtftar -L [-v] [-s setno] -f backup.bkf\n");
+	fprintf(stderr, "Where [options] can be any of:\n");
+	fprintf(stderr, "       -p         patching\n");
+	fprintf(stderr, "       --pax      use POSIX.1-2001 pax extended headers\n");
+	fprintf(stderr, "       -s setno   specify set number\n");
+	fprintf(stderr, "       -v         verbose\n");
 	exit(e);
 }
+
+static struct option long_options[] =
+{
+		{"pax", no_argument, NULL, 2001},
+		{0, 0, 0, 0}
+};
 
 static int seek_arg(const char *a, const char *b)
 {
@@ -76,7 +100,7 @@ int main(int argc, char *argv[])
 	struct tar_stream t;
 	unsigned int skip_flb;
 	int c, fd, setno, listonly, listindex;
-	int outfd, verbose;
+	int outfd, verbose, pax;
 	int patching;
 	off64_t idxpos;
 
@@ -96,11 +120,11 @@ int main(int argc, char *argv[])
 	fd = 0;
 	setno = 0;
 	listonly = listindex = 0;
-	verbose = 0;
+	verbose = pax = 0;
 	outfd = 1;
 	patching = 0;
 	dfn = 0;
-	while ((c = getopt(argc, argv, "pf:s:o:LlvX:h")) != -1) {
+	while ((c = getopt_long(argc, argv, "pf:s:o:LlvX:h", long_options, NULL)) != -1) {
 		switch (c) {
 		case 'p':
 			patching = 1;
@@ -137,6 +161,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'v':
 			verbose++;
+			break;
+		case 2001:
+			pax = 1;
 			break;
 		case 'X':
 			if (sizeof(idxpos) == sizeof(int)) {
@@ -226,7 +253,7 @@ int main(int argc, char *argv[])
 			if (((c = check_argmatch(patching, dfn, optind, argc, argv)) > -1)) {
 				/* write out TAR header */
 				tarout_file(&t, dfn+c, 0666, 0, 0, mtime,
-						mtf_stream_length(&s));
+						mtf_stream_length(&s), pax);
 				mtf_stream_copy(&s, outfd);
 				tarout_tail(&t);
 			}
@@ -250,7 +277,7 @@ int main(int argc, char *argv[])
 			/* have TAPE header/characteristics */
 			if (verbose) {
 				str = mtfscan_string(&s, mtfdb_tape_software(&s), '/');
-				fprintf(stderr, "MFT Generator: %s\n", str);
+				fprintf(stderr, "MTF Generator: %s\n", str);
 				free(str);
 
 				str = mtfscan_string(&s, mtfdb_tape_name(&s), '/');
@@ -301,7 +328,7 @@ int main(int argc, char *argv[])
 
 			mtime = mtfdb_volb_ctime(&s);
 			if (!listonly && (c = check_argmatch(patching, volume, optind, argc, argv)) > -1) {
-				tarout_dir(&t, volume+c, 0777, 0, 0, mtime);
+				tarout_dir(&t, volume+c, 0777, 0, 0, mtime, pax);
 				tarout_tail(&t);
 			}
 #ifdef DEBUG
@@ -331,7 +358,7 @@ int main(int argc, char *argv[])
 			}
 			sprintf(dfn, "%s/%s", volume, cwd);
 			if (!listonly && (c = check_argmatch(patching, dfn, optind, argc, argv)) > -1) {
-				tarout_dir(&t, dfn+c, 0777, 0, 0, mtime);
+				tarout_dir(&t, dfn+c, 0777, 0, 0, mtime, pax);
 				tarout_tail(&t);
 			}
 			free(dfn);
@@ -386,7 +413,7 @@ int main(int argc, char *argv[])
 				if (!listonly && ((c = check_argmatch(patching, dfn, optind, argc, argv)) > -1)) {
 					/* write out TAR header */
 					tarout_file(&t, dfn+c, 0666, 0, 0, mtime,
-							mtf_stream_length(&s));
+							mtf_stream_length(&s), pax);
 					mtf_stream_copy(&s, outfd);
 					tarout_tail(&t);
 				}

--- a/tar.h
+++ b/tar.h
@@ -2,7 +2,15 @@
 #define __tar_h
 
 #include <time.h>
+#include "md5/md5.h"
 
+/*
+ * Documentation for tar file format, and POSIX.1-2001 pax header extensions:
+ * https://en.wikipedia.org/wiki/Tar_(computing)
+ * https://www.manpagez.com/man/5/tar/
+ * https://www.systutorials.com/docs/linux/man/5-star/
+ * https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html
+ */
 struct tar_stream {
 	unsigned char block[512];
 	unsigned int cksum;
@@ -13,6 +21,16 @@ struct tar_stream {
 	int fd;
 };
 
+struct tar_filename {
+	const char *filename;
+	unsigned int filename_len;
+	const char *lfn;
+	unsigned int lfn_len;
+	const char *pfn;
+	unsigned int pfn_len;
+	char md5[33];
+};
+
 /* tar outputing code */
 int tarout_addch(struct tar_stream *t, int ch);
 int tarout_nullpad(struct tar_stream *t, const char *in, int inlen, int pad);
@@ -21,14 +39,14 @@ int tarout_octal(struct tar_stream *t, unsigned long long o, int digits, int siz
 int tarout_heading(struct tar_stream *t, int type,
 		const char *filename, int mode, int uid, int gid,
 		unsigned long long size, time_t mtime,
-		const char *linkname, const char *username);
+		const char *linkname, const char *username, int pax);
 
 int tarout_init(struct tar_stream *t, int fd);
 int tarout_dir(struct tar_stream *t, const char *filename,
-		int mode, int uid, int gid, time_t mtime);
+		int mode, int uid, int gid, time_t mtime, int pax);
 int tarout_file(struct tar_stream *t, const char *filename,
 		int mode, int uid, int gid, time_t mtime,
-		unsigned long long size);
+		unsigned long long size, int pax);
 int tarout_tail(struct tar_stream *t);
 
 #endif

--- a/tarout.c
+++ b/tarout.c
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 int tarout_init(struct tar_stream *t, int fd)
 {
@@ -48,83 +49,136 @@ int tarout_octal(struct tar_stream *t, unsigned long long o, int digits, int siz
 			sprintf(data, mask, (unsigned long long)o), size);
 }
 
-int tarout_heading(struct tar_stream *t, int type,
-		const char *filename, int mode, int uid, int gid,
+
+/* Calculate the md5 hash of full path and filename,
+ * for use in headers for POSIX.1-2001 pax format.
+ * This will be used as the filename in headers for
+ * files where the full path and filename do not fit.
+ */
+void tarout_md5(struct tar_filename *tf) {
+	md5_state_t state;
+	md5_byte_t digest[16];
+	md5_init(&state);
+	md5_append(&state, (const md5_byte_t *)tf->filename, strlen(tf->filename));
+	md5_finish(&state, digest);
+	int i;
+	for (i = 0; i < 16; i++) {
+		sprintf(tf->md5 + (i * 2), "%02x", digest[i]);
+	}
+}
+
+void tarout_process_filename(const char *filename, struct tar_filename *tf, int pax) {
+	/* the whole path and filename */
+	tf->filename = filename;
+	tf->filename_len = strlen(filename);
+
+	/* by default, the prefix and hash are empty */
+	tf->pfn = "";
+	tf->pfn_len = 0;
+	tf->md5[0] = 0;
+
+	if (strlen(filename) <= 100) {
+		/* entire path and filename fits in a 100 char field */
+		tf->lfn = filename;
+		tf->lfn_len = strlen(filename);
+		return;
+	}
+
+	/* ooh, not good */
+	/* take last 100 chars of path & filename, and look
+	 * for first slash in that as a breaking point.
+	 */
+	int i;
+	for (i = strlen(filename) - 100; filename[i]; i++) {
+		if (filename[i] == '/') break;
+	}
+	if (filename[i]) {
+		/* the filename and possibly part of the path fit
+		 * in 100 chars.  okay, THIS will be lfn
+		 */
+		tf->lfn = filename+i+1;
+		tf->lfn_len = strlen(tf->lfn);
+	} else {
+		/* the filename alone is more than 100 chars.
+		 * okay, simply not enough room. take first 100
+		 * chars of last path segment
+		 */
+		tf->lfn_len = 100;
+		for (tf->lfn = 0; i >= 0; i--) {
+			if (filename[i] == '/') {
+				tf->lfn = filename+i+1;
+				break;
+			}
+		}
+		if (!tf->lfn) {
+			/* forget it.
+			 * no slash was found, so this is just one very long filename
+			 */
+			tf->lfn = filename;
+		}
+		if (pax) {
+			/* part of filename was lost,
+			 * but we get to use POSIX pax headers to save it
+			 */
+			tarout_md5(tf);
+		}
+	}
+	if (tf->lfn > filename) {
+		/* there will be a prefix */
+		tf->pfn_len = tf->lfn - filename;
+		if (tf->pfn_len <= 155) {
+			/* entire prefix fits in a 155 char field */
+			tf->pfn = filename;
+		} else {
+			/* oh geez, this is huge.
+			 * take last 155 characters of prefix
+			 * then chomp up to first slash
+			 */
+			for (i = 0; tf->pfn_len > 155; i++) {
+				if (filename[i] == '/') {
+					tf->pfn_len = tf->lfn - (filename+i+1);
+				}
+			}
+			if (tf->pfn_len > 0) {
+				tf->pfn = filename+i;
+			}
+			if (pax && !tf->md5[0]) {
+				/* part of path was lost,
+				 * but we get to use POSIX pax headers to save it
+				 */
+				tarout_md5(tf);
+			}
+		}
+	}
+}
+
+
+/* Each pax metadata line includes its own line length! */
+int tarout_pax_line_length(int entry_len) {
+	/* Start with length of entry plus leading space and trailing newline. */
+	int line_len = entry_len + 2;
+	/* Add length of line_len to line_len. */
+	line_len += (int)log10(line_len) + 1;
+	/* Do it again, in case adding length of line_len increased length of line_len. */
+	line_len = ((int)log10(line_len) + 1) + entry_len + 2;
+	return line_len;
+}
+
+
+int tarout_write_heading(struct tar_stream *t, int type,
+		struct tar_filename *tf,
+		int mode, int uid, int gid,
 		unsigned long long size, time_t mtime,
 		const char *linkname, const char *username)
 {
 	int i;
 	unsigned long sum;
-	const char *lfn;
-	const char *pfn;
-	unsigned int lfn_len;
-	unsigned int pfn_len;
 
 	memset(t->block, 0, 512);
 	t->tptr = 0;
 
-	if (!filename) filename = "";
-	if (!linkname) linkname = "";
-	if (!username) username = "";
-
-	pfn = "";
-	pfn_len = 0;
-
-	if (strlen(filename) > 100) {
-		/* ooh, not good. */
-		for (i = strlen(filename) - 100; filename[i]; i++) {
-			if (filename[i] == '/') break;
-		}
-		if (filename[i]) {
-			/* okay, THIS will be lfn */
-			lfn = filename+i+1;
-			lfn_len = strlen(lfn);
-		} else {
-			/* okay, simply not enough room. take first 100
-			 * chars of last path segment
-			 */
-			lfn_len = 100;
-			for (lfn = 0; i >= 0; i--) {
-				if (filename[i] == '/') {
-					lfn = filename+i+1;
-					break;
-				}
-			}
-			if (!lfn) {
-				/* forget it */
-				lfn = filename;
-			}
-		}
-		if (lfn > filename) {
-			i = lfn - filename;
-			if (i > 155) {
-				/* oh geez, this is huge.
-				 * take last 155 characters of path
-				 * then chomp up to slash
-				 */
-				pfn_len = i;
-				for (i = 0; i - pfn_len > 155;) {
-					for (; i < pfn_len; i++) {
-						if (filename[i] == '/') {
-							pfn_len -= (i+1);
-						}
-					}
-				}
-				if (pfn_len > 0) {
-					pfn = filename+i+1;
-				}
-			} else {
-				pfn = filename;
-				pfn_len = i;
-			}
-		}
-	} else {
-		lfn = filename;
-		lfn_len = strlen(filename);
-	}
-
 	t->hold = 1;
-	if (!tarout_nullpad(t, lfn, lfn_len, 100)) return 0;
+	if (!tarout_nullpad(t, tf->lfn, tf->lfn_len, 100)) return 0;
 	if (!tarout_octal(t, (unsigned long long)mode, 6, 8)) return 0;
 	if (!tarout_octal(t, (unsigned long long)uid, 6, 8)) return 0;
 	if (!tarout_octal(t, (unsigned long long)gid, 6, 8)) return 0;
@@ -139,7 +193,7 @@ int tarout_heading(struct tar_stream *t, int type,
 	if (!tarout_nullpad(t, "", 0, 32)) return 0;
 	if (!tarout_nullpad(t, "0", 1, 8)) return 0;
 	if (!tarout_nullpad(t, "0", 1, 8)) return 0;
-	if (!tarout_nullpad(t, pfn, pfn_len, 155)) return 0;
+	if (!tarout_nullpad(t, tf->pfn, tf->pfn_len, 155)) return 0;
 
 	/* calculate checksum (skipping 8byte chunk) */
 	for (i = 0, sum = 0; i < 512; i++) {
@@ -164,18 +218,92 @@ int tarout_heading(struct tar_stream *t, int type,
 }
 
 
+int tarout_heading(struct tar_stream *t, int type,
+		const char *filename, int mode, int uid, int gid,
+		unsigned long long size, time_t mtime,
+		const char *linkname, const char *username, int pax)
+{
+	struct tar_filename tf;
+
+	if (!filename) filename = "";
+	if (!linkname) linkname = "";
+	if (!username) username = "";
+
+	tarout_process_filename(filename, &tf, pax);
+	char pax_filename[101];
+	if (pax) {
+		int create_pax = 0;
+		/* POSIX pax is enabled. */
+		if (tf.md5[0]) {
+			/* Part of path or filename was lost. */
+			create_pax = 1;
+			/* We will use <md5>.meta for the metadata filename, and
+			 * <md5>.file for the actual file filename.  This will allow
+			 * users of non-compatible tar programs to sort things out manually.
+			 */
+			tf.pfn = "";
+			tf.pfn_len = 0;
+			tf.lfn = pax_filename;
+			tf.lfn_len = snprintf(pax_filename, 101, "%s.meta", tf.md5);
+		}
+		if (size > 077777777777) {
+			create_pax = 1;
+		}
+		if (create_pax) {
+			/* Create POSIX pax metadata file:
+			 * <linelen> path=<filename>\n
+			 * <linelen> size=<size>\n
+			 */
+			int path_len = tarout_pax_line_length(strlen(filename) + 5);	/* path=%s */
+			int size_len;
+			if (size == 0) {
+				/* Avoid log10(0) */
+				size_len = 9;	/* 9 size=0\n */
+			} else {
+				size_len = tarout_pax_line_length(((int)log10(size) + 1) + 5);	/* size=%llu */
+			}
+			int meta_block_len = path_len + size_len + 1;
+			/* Round up to next multiple of 512. */
+			int remainder = meta_block_len % 512;
+			if (remainder != 0) {
+				meta_block_len += (512 - remainder);
+			}
+			char metadata[meta_block_len];
+			memset(metadata, 0, meta_block_len);
+			snprintf(metadata, meta_block_len, "%d path=%s\n%d size=%llu\n", path_len, filename, size_len, size);
+			int meta_len = strlen(metadata);
+			/* Write POSIX pax metadata header. */
+			tarout_write_heading(t, 'x', &tf, mode, uid, gid, meta_len, mtime, linkname, username);
+			/* Write POSIX pax metadata file. */
+			bwrite(t->fd, (unsigned char *)metadata, meta_block_len);
+			if (tf.md5[0]) {
+				/* Now that the POSIX pax metadata is written using <md5>.meta,
+				 * set up the filename for the file using <md5>.file.
+				 * (Only if filename was too long above.)
+				 */
+				tf.lfn_len = snprintf(pax_filename, 101, "%s.file", tf.md5);
+			}
+			/* Now continue on to write the real header for this file or directory... */
+		}
+	}
+
+	return tarout_write_heading(t, type, &tf, mode, uid, gid,
+		size, mtime, linkname, username);
+}
+
+
 int tarout_dir(struct tar_stream *t, const char *filename,
-		int mode, int uid, int gid, time_t mtime)
+		int mode, int uid, int gid, time_t mtime, int pax)
 {
 	return tarout_heading(t, '5', filename, mode, uid, gid,
-			0, mtime, 0, 0);
+			0, mtime, 0, 0, pax);
 }
 int tarout_file(struct tar_stream *t, const char *filename,
 		int mode, int uid, int gid, time_t mtime,
-		unsigned long long size)
+		unsigned long long size, int pax)
 {
 	return tarout_heading(t, '0', filename, mode, uid, gid,
-			size, mtime, 0, 0);
+			size, mtime, 0, 0, pax);
 }
 
 int tarout_tail(struct tar_stream *t)


### PR DESCRIPTION
This removes the limits on both path length and file size in the generated tar file, if the user has a modern pax-compatible tar implementation.
The path corruption fix from PR #1 is also incorporated here.