### PR TITLE
Fix warning re: unread variable

### DIFF
--- a/mtftar.c
+++ b/mtftar.c
@@ -112,7 +112,6 @@ int main(int argc, char *argv[])
 
 	char *fn, *dfn;
 	char *str;
-	int skipping_set;
 
 	time_t mtime;
 	int r;
@@ -206,7 +205,6 @@ int main(int argc, char *argv[])
 	if (fd == 0 && isatty(0)) usage(1);
 	mtfscan_init(&s, fd);
 
-	skipping_set = 0;
 	if (!listonly) tarout_init(&t, outfd);
 
 	if (dfn && skip_flb) {
@@ -299,11 +297,6 @@ int main(int argc, char *argv[])
 #endif
 		} else if (mtfdb_sset_type(&s)) {
 			/* set begin */
-			if (setno) {
-				if (mtfdb_sset_num(&s) != setno) {
-					skipping_set = 1;
-				}
-			}
 			if (verbose) {
 				fprintf(stderr, "-- Set#%d\n", mtfdb_sset_num(&s));
 
@@ -432,7 +425,6 @@ int main(int argc, char *argv[])
 
 		} else if (mtfdb_eset_type(&s)) {
 			if (setno) {
-				skipping_set = 0;
 				if (setno == mtfdb_eset_seq(&s)) {
 					/* we're all done */
 					break;


### PR DESCRIPTION
Fixes the following warning:
```
cc -Wall -O3 -D_GNU_SOURCE   -c -o mtftar.o mtftar.c
mtftar.c: In function 'main':
mtftar.c:115:13: warning: variable 'skipping_set' set but not used [-Wunused-but-set-variable]
  115 |         int skipping_set;
      |             ^~~~~~~~~~~~
cc   mtftar.o mtfscan.o mtfheader.o mtfstream.o tarout.o util.o md5/md5.o /usr/lib64/libm.so   -o mtftar
```